### PR TITLE
ci: enable GitHub Pages with Jekyll Cayman theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+title: Awesome ECS
+description: A curated list of Entity-Component-System (ECS) libraries and resources.


### PR DESCRIPTION
## Summary
- Add `_config.yml` with Cayman theme to enable GitHub Pages from main branch
- Site will be live at https://jslee02.github.io/awesome-entity-component-system/