### PR TITLE
improve: rewrite fetch_metadata.py with single API call and better UX

### DIFF
--- a/scripts/fetch_metadata.py
+++ b/scripts/fetch_metadata.py
@@ -56,10 +56,13 @@ def fetch_repo_metadata(owner_repo: str) -> dict | None:
         meta["last_commit"] = data["pushed_at"][:10]
     if data.get("archived") is True:
         meta["archived"] = True
-    if data.get("license") and data["license"].get("spdx_id"):
-        spdx = data["license"]["spdx_id"]
-        if spdx != "NOASSERTION":
+    if data.get("license"):
+        lic = data["license"]
+        spdx = lic.get("spdx_id")
+        if spdx and spdx != "NOASSERTION":
             meta["license"] = spdx
+        elif lic.get("name"):
+            meta["license"] = lic["name"]
     if data.get("language"):
         meta["language"] = data["language"]
     return meta


### PR DESCRIPTION
## Summary
- **Single API call per entry**: Use `pushed_at` from the repo endpoint instead of a separate `/commits` call — halves the number of API requests (91 → 91, was 182)
- **`--dry-run` flag**: Print fetched metadata without writing to YAML files
- **Progress output**: Per-entry status with star count during fetch
- **`GH_TOKEN` fallback**: Checks both `GITHUB_TOKEN` and `GH_TOKEN` environment variables
- **Better error handling**: Specific messages for 404, 403 (rate limit), and network errors
- **Cleaner structure**: Aligned with awesome-robotics-libraries implementation (PR #65)

### Usage
```bash
# Normal run
GITHUB_TOKEN=... python scripts/fetch_metadata.py

# Preview without writing
GITHUB_TOKEN=... python scripts/fetch_metadata.py --dry-run
```