### PR TITLE
feat: add separate issue template for resource suggestions

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest-library.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-library.yml
@@ -1,5 +1,5 @@
 name: Suggest a Library
-description: Suggest an ECS library or resource to add to the list
+description: Suggest an ECS library, game engine, or tool to add to the list
 title: "[Suggestion] "
 labels: ["suggestion"]
 body:
@@ -50,12 +50,6 @@ body:
         - "Graphics Engines"
         - "Physics Libraries"
         - "Benchmarks"
-        - "Blog Posts"
-        - "Talks & Slides"
-        - "Books"
-        - "Tutorials"
-        - "Lists"
-        - "Other"
         - "New Category"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/suggest-resource.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-resource.yml
@@ -1,0 +1,48 @@
+name: Suggest a Resource
+description: Suggest a blog post, talk, book, tutorial, or other ECS resource
+title: "[Resource] "
+labels: ["suggestion", "resource"]
+body:
+  - type: input
+    id: name
+    attributes:
+      label: Resource Title
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      description: Direct link to the resource
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Blog Posts
+        - "Talks & Slides"
+        - Books
+        - Tutorials
+        - Lists
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Brief description of what this resource covers (optional for blog posts and talks)
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: Related to ECS, data-oriented design, or the entity-component-system pattern
+        - label: Publicly accessible (not behind a paywall, or at least has a free summary)
+        - label: Not a duplicate of an existing entry


### PR DESCRIPTION
## Summary

- **New template** `suggest-resource.yml` for blog posts, talks, books, tutorials, and other non-library resources — lightweight checklist (ECS relevance, public access, not duplicate) without library-specific scoring (stars, activity, maturity)
- **Narrowed** `suggest-library.yml` to library/engine/benchmark categories only — removed resource categories (Blog Posts, Talks, Books, etc.) that now have their own template
- Contributors now see two clear options when creating an issue: "Suggest a Library" vs "Suggest a Resource"