### PR TITLE
fix: use default-branch commit date for activity

### DIFF
--- a/scripts/evaluate_entry.py
+++ b/scripts/evaluate_entry.py
@@ -13,17 +13,22 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import sys
 import urllib.error
-import urllib.request
 from datetime import date
 from pathlib import Path
 
 import yaml
 
-API_BASE = "https://api.github.com"
+try:
+    from scripts.github_metadata import (
+        API_BASE,
+        fetch_default_branch_commit_date,
+        fetch_json,
+    )
+except ModuleNotFoundError:
+    from github_metadata import API_BASE, fetch_default_branch_commit_date, fetch_json
 
 CATEGORY_TO_YAML = {
     "ECS Libraries: C/C++": "ecs-libraries",
@@ -78,24 +83,12 @@ GUIDANCE = {
         "This issue will be automatically re-evaluated once the project matures — no action needed from you."
     ),
 }
+USER_AGENT = "awesome-ecs-evaluator"
 
 
-def _github_headers(token: str | None = None) -> dict[str, str]:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "awesome-ecs-evaluator",
-    }
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
-
-
-def _fetch_json(url: str, token: str | None = None) -> dict | None:
-    req = urllib.request.Request(url, headers=_github_headers(token))
+def _fetch_json(url: str, token: str | None = None) -> dict | list | None:
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            return json.loads(resp.read())
+        return fetch_json(url, token, USER_AGENT)
     except urllib.error.HTTPError as e:
         print(f"ERROR: HTTP {e.code} for {url}", file=sys.stderr)
         return None
@@ -169,6 +162,25 @@ def evaluate(
     archived = data.get("archived", False)
     created_at = data.get("created_at", "")[:10]
     pushed_at = data.get("pushed_at", "")[:10]
+    default_branch = data.get("default_branch") or ""
+    last_commit = None
+    if default_branch:
+        try:
+            last_commit = fetch_default_branch_commit_date(
+                owner_repo, default_branch, token, USER_AGENT
+            )
+        except urllib.error.HTTPError as e:
+            print(
+                f"ERROR: HTTP {e.code} for {API_BASE}/repos/{owner_repo}/commits",
+                file=sys.stderr,
+            )
+        except (urllib.error.URLError, TimeoutError) as e:
+            print(
+                f"ERROR: {e} for {API_BASE}/repos/{owner_repo}/commits",
+                file=sys.stderr,
+            )
+    if not last_commit:
+        last_commit = pushed_at
     license_spdx = None
     if (
         data.get("license")
@@ -192,15 +204,16 @@ def evaluate(
     }
 
     active = False
-    if pushed_at:
+    if last_commit:
         try:
-            last_push = date.fromisoformat(pushed_at)
-            active = (today - last_push).days <= 730
+            latest_commit = date.fromisoformat(last_commit)
+            active = (today - latest_commit).days <= 730
         except ValueError:
             pass
     checks["activity"] = {
         "pass": active and not archived,
-        "detail": f"last push {pushed_at}" + (" ⚠️ ARCHIVED" if archived else ""),
+        "detail": f"last default-branch commit {last_commit or 'unknown'}"
+        + (" ⚠️ ARCHIVED" if archived else ""),
     }
 
     checks["documentation"] = {
@@ -252,7 +265,9 @@ def evaluate(
         reason = f"Passes {auto_score}/{auto_total} auto-checkable criteria"
 
     # _meta block ready for YAML insertion
-    meta = {"stars": stars, "last_commit": pushed_at}
+    meta = {"stars": stars}
+    if last_commit:
+        meta["last_commit"] = last_commit
     if archived:
         meta["archived"] = True
     if license_spdx:
@@ -268,7 +283,7 @@ def evaluate(
         "stars": stars,
         "archived": archived,
         "created": created_at,
-        "last_push": pushed_at,
+        "last_commit": last_commit or "",
         "has_readme": has_readme,
         "has_license": license_spdx is not None,
         "license_spdx": license_spdx,
@@ -320,7 +335,7 @@ def format_report(result: dict) -> str:
     lines.append("|-------|-------|")
     lines.append(f"| Stars | {result['stars']:,} |")
     lines.append(f"| Created | {result['created']} |")
-    lines.append(f"| Last Push | {result['last_push']} |")
+    lines.append(f"| Last Commit (default branch) | {result['last_commit'] or 'unknown'} |")
     lines.append(f"| Archived | {'⚠️ Yes' if result['archived'] else 'No'} |")
     lines.append(f"| README | {'✅' if result['has_readme'] else '❌'} |")
     lines.append(

--- a/scripts/fetch_metadata.py
+++ b/scripts/fetch_metadata.py
@@ -4,39 +4,30 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import sys
 import time
 import urllib.error
-import urllib.request
 from pathlib import Path
 
 import yaml
 
-API_BASE = "https://api.github.com"
+try:
+    from scripts.github_metadata import fetch_default_branch_commit_date, fetch_json
+except ModuleNotFoundError:
+    from github_metadata import fetch_default_branch_commit_date, fetch_json
+
 RATE_LIMIT_PAUSE_AUTH = 0.5
 RATE_LIMIT_PAUSE_NOAUTH = 2
-
-
-def _github_headers() -> dict[str, str]:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "awesome-ecs-metadata-bot",
-    }
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
-
-
+USER_AGENT = "awesome-ecs-metadata-bot"
 def fetch_repo_metadata(owner_repo: str) -> dict | None:
-    url = f"{API_BASE}/repos/{owner_repo}"
-    req = urllib.request.Request(url, headers=_github_headers())
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read())
+        data = fetch_json(
+            f"https://api.github.com/repos/{owner_repo}",
+            token,
+            USER_AGENT,
+        )
     except urllib.error.HTTPError as e:
         if e.code == 404:
             print(f"  WARN: {owner_repo} — 404 Not Found", file=sys.stderr)
@@ -50,10 +41,29 @@ def fetch_repo_metadata(owner_repo: str) -> dict | None:
         return None
 
     meta: dict = {}
+    last_commit = None
     if "stargazers_count" in data:
         meta["stars"] = data["stargazers_count"]
-    if data.get("pushed_at"):
-        meta["last_commit"] = data["pushed_at"][:10]
+    default_branch = data.get("default_branch") or ""
+    if default_branch:
+        try:
+            last_commit = fetch_default_branch_commit_date(
+                owner_repo, default_branch, token, USER_AGENT
+            )
+        except urllib.error.HTTPError as e:
+            print(
+                f"  WARN: {owner_repo} — commit lookup HTTP {e.code}, falling back to pushed_at",
+                file=sys.stderr,
+            )
+        except (urllib.error.URLError, TimeoutError) as e:
+            print(
+                f"  WARN: {owner_repo} — commit lookup failed ({e}), falling back to pushed_at",
+                file=sys.stderr,
+            )
+    if not last_commit and data.get("pushed_at"):
+        last_commit = data["pushed_at"][:10]
+    if last_commit:
+        meta["last_commit"] = last_commit
     if data.get("archived") is True:
         meta["archived"] = True
     if data.get("license"):

--- a/scripts/github_metadata.py
+++ b/scripts/github_metadata.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Helpers for fetching GitHub repository metadata."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_BASE = "https://api.github.com"
+
+
+def github_headers(token: str | None = None, user_agent: str = "") -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": user_agent or "awesome-ecs-bot",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_json(
+    url: str,
+    token: str | None = None,
+    user_agent: str = "",
+) -> dict | list | None:
+    req = urllib.request.Request(url, headers=github_headers(token, user_agent))
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError:
+        raise
+    except (urllib.error.URLError, TimeoutError):
+        raise
+
+
+def fetch_default_branch_commit_date(
+    owner_repo: str,
+    default_branch: str,
+    token: str | None = None,
+    user_agent: str = "",
+) -> str | None:
+    branch_ref = urllib.parse.quote(default_branch, safe="")
+    data = fetch_json(
+        f"{API_BASE}/repos/{owner_repo}/commits?per_page=1&sha={branch_ref}",
+        token,
+        user_agent,
+    )
+    if not isinstance(data, list) or not data:
+        return None
+
+    commit = data[0].get("commit", {})
+    committer = commit.get("committer") or {}
+    author = commit.get("author") or {}
+    commit_date = (committer.get("date") or author.get("date") or "")[:10]
+    return commit_date or None


### PR DESCRIPTION
## Summary
- use the latest commit on the repository default branch for activity evaluation instead of `pushed_at`
- share the GitHub metadata lookup logic across evaluation and metadata refresh
- keep a fallback to `pushed_at` if the default-branch commit lookup fails

## Why
GitHub's repository `pushed_at` value updates on pushes to any branch, including unmerged PR branches. That can make a stale repository look active when no commit has landed on the default branch recently.

This directly addresses issue #63.

Closes #63

## Changes
- added `scripts/github_metadata.py` to centralize GitHub API helpers and default-branch commit lookup
- updated `scripts/evaluate_entry.py` to score activity from the latest default-branch commit date and report it as such
- updated `scripts/fetch_metadata.py` to store `_meta.last_commit` from the default branch
- made the helper imports safe for direct script execution via `python3 scripts/...`

## Verification
- `python3 scripts/evaluate_entry.py --help`
- `python3 scripts/fetch_metadata.py --help`
- `python3 -m py_compile scripts/github_metadata.py scripts/evaluate_entry.py scripts/fetch_metadata.py`
- `python3 scripts/validate_entries.py`
- ran mocked smoke tests covering default-branch commit lookup and `pushed_at` fallback behavior
