### PR TITLE
Add Woven-ECS entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ _Libraries and frameworks implementing the Entity-Component-System pattern._
 * 💀 [ECSY](https://github.com/ecsyjs/ecsy) - Entity Component System for javascript. [⭐ 1.2k](https://github.com/ecsyjs/ecsy)
 * 🟢 [miniplex](https://github.com/hmans/miniplex) - The gentle game entity manager, focused on ease of use and developer experience. [⭐ 997](https://github.com/hmans/miniplex)
 * 🟡 [Thyseus](https://github.com/JaimeGensler/thyseus) - An archetypal Entity Component System, built entirely in Typescript. [⭐ 86](https://github.com/JaimeGensler/thyseus)
+* 🟢 [Woven-ECS](https://woven-ecs.dev/) - A multithreaded ECS framework for TypeScript aimed at collaborative browser applications. [⭐ 7](https://github.com/WillH0lt/woven-ecs)
 
 #### Zig
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ _Articles and blog posts about ECS and data-oriented design._
 * [Systems Interaction in Entity-Component-System (events)](https://medium.com/@ben.rasooli/systems-interaction-in-entity-component-system-events-4a050153c8ac)
 * [Understand data-oriented design](https://learn.unity.com/tutorial/part-1-understand-data-oriented-design)
 * [Unity ECS series](https://gametorrahod.com/tag/unity-dots/)
-* [WickedEngine's ECS implementation](https://wickedengine.net/2019/09/entity-component-system/)
+* [WickedEngine's ECS implementation](https://web.archive.org/web/20240531144559/https://wickedengine.net/2019/09/entity-component-system/)
 
 ### [Talks & Slides](#contents)
 

--- a/data/blog-posts.yaml
+++ b/data/blog-posts.yaml
@@ -19,4 +19,4 @@
 - name: "Seba's Lab"
   url: https://www.sebaslab.com/
 - name: WickedEngine's ECS implementation
-  url: https://wickedengine.net/2019/09/entity-component-system/
+  url: https://web.archive.org/web/20240531144559/https://wickedengine.net/2019/09/entity-component-system/

--- a/data/ecs-libraries.yaml
+++ b/data/ecs-libraries.yaml
@@ -563,6 +563,16 @@
     last_commit: '2024-05-06'
     license: MIT
     language: TypeScript
+- name: Woven-ECS
+  description: A multithreaded ECS framework for TypeScript aimed at collaborative browser applications
+  url: https://woven-ecs.dev/
+  github: WillH0lt/woven-ecs
+  _subsection: JavaScript / TypeScript
+  _meta:
+    stars: 7
+    last_commit: '2026-03-22'
+    license: MIT
+    language: TypeScript
 - name: mach-ecs
   description: Entity Component System from first-principles designed for Zig
   url: https://github.com/hexops-graveyard/mach-ecs


### PR DESCRIPTION
## Summary
Add Woven-ECS to the JavaScript / TypeScript ECS libraries section.

## Validation
- python3 scripts/generate_readme.py
- python3 scripts/validate_entries.py

Closes #60
