### PR TITLE
Use shared maintenance workflows

### DIFF
--- a/.github/workflows/protect-readme.yml
+++ b/.github/workflows/protect-readme.yml
@@ -1,0 +1,10 @@
+name: Protect README
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+
+jobs:
+  check-readme:
+    uses: jslee02/awesome-list-infra/.github/workflows/protect-readme.yml@main

--- a/.github/workflows/refresh-metadata.yml
+++ b/.github/workflows/refresh-metadata.yml
@@ -1,0 +1,14 @@
+name: Refresh Metadata
+
+on:
+  schedule:
+    - cron: "0 8 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    uses: jslee02/awesome-list-infra/.github/workflows/refresh-metadata.yml@main


### PR DESCRIPTION
## Summary
- Replace copied README-protection workflow logic with the shared reusable workflow
- Add scheduled metadata refresh workflow where the repo already has `scripts/fetch_metadata.py`
- Keep metadata refresh jobs staggered across the week to avoid unnecessary API bursts

## Validation
- Parsed all updated workflow YAML with PyYAML
- `git diff --check`
