### PR TITLE
fix: restore broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Contributions are very welcome! Please read the [contribution guidelines](CONTRI
 
 ## [Star History](#contents)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jslee02/awesome-entity-component-system&type=Date)](https://star-history.com/#jslee02/awesome-entity-component-system)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jslee02/awesome-entity-component-system&type=Date)](https://star-history.dera.page/#jslee02/awesome-entity-component-system)
 
 ## [License](#contents)
 

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -298,8 +298,8 @@ def generate_readme(sort_key: str = "name") -> str:
     lines.append("")
     lines.append(
         "[![Star History Chart]"
-        "(https://api.star-history.com/svg?repos=jslee02/awesome-entity-component-system&type=Date)]"
-        "(https://star-history.com/#jslee02/awesome-entity-component-system)"
+        "(https://star-history.dera.page/svg?repos=jslee02/awesome-entity-component-system&type=Date)]"
+        "(https://star-history.dera.page/#jslee02/awesome-entity-component-system)"
     )
     lines.append("")
     lines.append("## [License](#contents)")


### PR DESCRIPTION
The Star History chart at the bottom of the README is currently broken. This change points the chart image and its link to a working endpoint so contributors can again see the project's star growth over time.